### PR TITLE
Pass image ID for testing

### DIFF
--- a/hack/build.sh
+++ b/hack/build.sh
@@ -13,6 +13,9 @@
 # OPENSHIFT_NAMESPACES - Which of available versions (subdirectories) should be
 #       put into openshift/ namespace.
 
+set -o errexit
+set -o pipefail
+
 OS=${1-$OS}
 VERSION=${2-$VERSION}
 
@@ -37,7 +40,10 @@ function docker_build_with_version {
   if [[ "${UPDATE_BASE}" == "1" ]]; then
     BUILD_OPTIONS+=" --pull=true"
   fi
-  docker build ${BUILD_OPTIONS} -t ${IMAGE_NAME} -f "${dockerfile}.version" .
+  local build_output=$(mktemp)
+  docker build ${BUILD_OPTIONS} -t ${IMAGE_NAME} -f "${dockerfile}.version" . | tee $build_output
+  IMAGE_ID="$(awk 'END {print $NF}' $build_output)"
+  rm $build_output
   if [[ "${SKIP_SQUASH}" != "1" ]]; then
     squash "${dockerfile}.version"
   fi
@@ -72,6 +78,7 @@ for dir in ${dirs}; do
   esac
 
   IMAGE_NAME="${NAMESPACE}${BASE_IMAGE_NAME}-${dir//./}-${OS}"
+  IMAGE_ID=
 
   if [[ -v TEST_MODE ]]; then
     IMAGE_NAME+="-candidate"
@@ -87,11 +94,11 @@ for dir in ${dirs}; do
   fi
 
   if [[ -v TEST_MODE ]]; then
-    IMAGE_NAME=${IMAGE_NAME} test/run
+    IMAGE_NAME=${IMAGE_ID} test/run
 
     if [[ $? -eq 0 ]] && [[ "${TAG_ON_SUCCESS}" == "true" ]]; then
       echo "-> Re-tagging ${IMAGE_NAME} image to ${IMAGE_NAME%"-candidate"}"
-      docker tag $IMAGE_NAME ${IMAGE_NAME%"-candidate"}
+      docker tag $IMAGE_ID ${IMAGE_NAME%"-candidate"}
     fi
   fi
 


### PR DESCRIPTION
When running test/run use image ID instead of IMAGE_NAME. This allows parallel testing of images (for example parallel testing of PRs in Jenkins).

This is similar PR as for sclorg/mariadb-container#14. @hhorak Please take a look.