### PR TITLE
Update Dockerfiles

### DIFF
--- a/1-agent/Dockerfile
+++ b/1-agent/Dockerfile
@@ -36,7 +36,7 @@ ENV USER_THERMOSTAT_HOME /root/.thermostat
 EXPOSE $THERMOSTAT_CMDC_PORT
 
 RUN yum install -y centos-release-scl-rh && \
-    INSTALL_PKGS="thermostat1 && \
+    INSTALL_PKGS="thermostat1" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum erase -y java-1.8.0-openjdk-headless && \

--- a/1-agent/Dockerfile
+++ b/1-agent/Dockerfile
@@ -15,8 +15,17 @@ FROM centos:centos7
 ENV THERMOSTAT_VERSION=1.4 \
     HOME=/root
 
-LABEL io.k8s.description="A monitoring and serviceability tool for OpenJDK." \
-      io.k8s.display-name="Thermostat Agent 1.4"
+ENV SUMMARY="A monitoring and serviceability tool for OpenJDK."	\
+    DESCRIPTION="The powerful, free and open source instrumentation tool for the Hotspot JVM."
+
+LABEL summary="$SUMMARY" \
+      description="$DESCRIPTION" \
+      io.k8s.description="$SUMMARY" \
+      io.k8s.display-name="Thermostat Agent 1.4" \
+      com.redhat.component="thermostat1-agent-docker" \
+      name="centos/thermostat-1-agent-centos7" \
+      version="1.4" \
+      release="1"
 
 ENV THERMOSTAT_CMDC_ADDR 127.0.0.1
 ENV THERMOSTAT_CMDC_PORT 12000

--- a/1-agent/Dockerfile
+++ b/1-agent/Dockerfile
@@ -27,9 +27,12 @@ ENV USER_THERMOSTAT_HOME /root/.thermostat
 EXPOSE $THERMOSTAT_CMDC_PORT
 
 RUN yum install -y centos-release-scl-rh && \
-    yum install -y --setopt=tsflags=nodocs thermostat1 && \
+    INSTALL_PKGS="thermostat1 && \
+    yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
     yum erase -y java-1.8.0-openjdk-headless && \
     yum clean all
+
 COPY thermostat-user-home-config ${USER_THERMOSTAT_HOME}
 COPY root /
 

--- a/1-agent/Dockerfile
+++ b/1-agent/Dockerfile
@@ -31,7 +31,7 @@ RUN yum install -y centos-release-scl-rh && \
     yum erase -y java-1.8.0-openjdk-headless && \
     yum clean all
 COPY thermostat-user-home-config ${USER_THERMOSTAT_HOME}
-ADD root /
+COPY root /
 
 # Get prefix path and path to scripts rather than hard-code them in scripts
 ENV CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/thermostat \

--- a/1-agent/Dockerfile.rhel7
+++ b/1-agent/Dockerfile.rhel7
@@ -36,9 +36,12 @@ EXPOSE $THERMOSTAT_CMDC_PORT
 RUN yum install -y yum-utils && \
     yum-config-manager --enable rhel-server-rhscl-7-rpms && \
     yum-config-manager --enable rhel-7-server-optional-rpms && \
-    yum install -y --setopt=tsflags=nodocs thermostat1 && \
+    INSTALL_PKGS="thermostat1 && \
+    yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
     yum erase -y java-1.8.0-openjdk-headless && \
     yum clean all
+
 COPY thermostat-user-home-config ${USER_THERMOSTAT_HOME}
 COPY root /
 

--- a/1-agent/Dockerfile.rhel7
+++ b/1-agent/Dockerfile.rhel7
@@ -40,7 +40,7 @@ RUN yum install -y yum-utils && \
     yum erase -y java-1.8.0-openjdk-headless && \
     yum clean all
 COPY thermostat-user-home-config ${USER_THERMOSTAT_HOME}
-ADD root /
+COPY root /
 
 # Get prefix path and path to scripts rather than hard-code them in scripts
 ENV CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/thermostat \

--- a/1-agent/Dockerfile.rhel7
+++ b/1-agent/Dockerfile.rhel7
@@ -15,15 +15,17 @@ FROM rhel7
 ENV THERMOSTAT_VERSION=1.4 \
     HOME=/root
 
-LABEL io.k8s.description="A monitoring and serviceability tool for OpenJDK." \
-      io.k8s.display-name="Thermostat Agent 1.4"
+ENV SUMMARY="A monitoring and serviceability tool for OpenJDK." \
+    DESCRIPTION="The powerful, free and open source instrumentation tool for the Hotspot JVM."
 
-# Labels consumed by Red Hat build service
-LABEL com.redhat.component="thermostat1-agent-docker" \
+LABEL summary="$SUMMARY" \
+      description="$DESCRIPTION" \
+      io.k8s.description="$SUMMARY" \
+      io.k8s.display-name="Thermostat Agent 1.4" \
+      com.redhat.component="thermostat1-agent-docker" \
       name="rhscl/thermostat-1-agent-rhel7" \
       version="1.4" \
-      release="8" \
-      architecture="x86_64"
+      release="8"
 
 ENV THERMOSTAT_CMDC_ADDR 127.0.0.1
 ENV THERMOSTAT_CMDC_PORT 12000

--- a/1-agent/Dockerfile.rhel7
+++ b/1-agent/Dockerfile.rhel7
@@ -38,7 +38,7 @@ EXPOSE $THERMOSTAT_CMDC_PORT
 RUN yum install -y yum-utils && \
     yum-config-manager --enable rhel-server-rhscl-7-rpms && \
     yum-config-manager --enable rhel-7-server-optional-rpms && \
-    INSTALL_PKGS="thermostat1 && \
+    INSTALL_PKGS="thermostat1" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum erase -y java-1.8.0-openjdk-headless && \

--- a/16-agent/Dockerfile.rhel7
+++ b/16-agent/Dockerfile.rhel7
@@ -39,7 +39,7 @@ EXPOSE $THERMOSTAT_CMDC_PORT
 RUN yum install -y yum-utils && \
     yum-config-manager --enable rhel-server-rhscl-7-rpms && \
     yum-config-manager --enable rhel-7-server-optional-rpms && \
-    INSTALL_PKGS="rh-thermostat16 && \
+    INSTALL_PKGS="rh-thermostat16" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum erase -y java-1.8.0-openjdk-headless && \

--- a/16-agent/Dockerfile.rhel7
+++ b/16-agent/Dockerfile.rhel7
@@ -15,15 +15,17 @@ FROM rhel7
 ENV THERMOSTAT_VERSION=1.6 \
     HOME=/root
 
-LABEL io.k8s.description="A monitoring and serviceability tool for OpenJDK." \
-      io.k8s.display-name="Thermostat Agent 1.6"
+ENV SUMMARY="A monitoring and serviceability tool for OpenJDK."	\
+    DESCRIPTION="The powerful, free and open source instrumentation tool for the Hotspot JVM."
 
-# Labels consumed by Red Hat build service
-LABEL com.redhat.component="rh-thermostat16-agent-docker" \
+LABEL summary="$SUMMARY" \
+      description="$DESCRIPTION" \
+      io.k8s.description="$SUMMARY" \
+      io.k8s.display-name="Thermostat Agent 1.6" \
+      com.redhat.component="rh-thermostat16-agent-docker" \
       name="rhscl/thermostat-16-agent-rhel7" \
       version="1.6" \
-      release="1" \
-      architecture="x86_64"
+      release="1"
 
 ENV THERMOSTAT_CMDC_ADDR 127.0.0.1
 ENV THERMOSTAT_CMDC_PORT 12000

--- a/16-agent/Dockerfile.rhel7
+++ b/16-agent/Dockerfile.rhel7
@@ -41,7 +41,7 @@ RUN yum install -y yum-utils && \
     yum erase -y java-1.8.0-openjdk-headless && \
     yum clean all
 COPY thermostat-user-home-config ${USER_THERMOSTAT_HOME}
-ADD root /
+COPY root /
 
 # Get prefix path and path to scripts rather than hard-code them in scripts
 ENV CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/thermostat \

--- a/16-agent/Dockerfile.rhel7
+++ b/16-agent/Dockerfile.rhel7
@@ -37,9 +37,12 @@ EXPOSE $THERMOSTAT_CMDC_PORT
 RUN yum install -y yum-utils && \
     yum-config-manager --enable rhel-server-rhscl-7-rpms && \
     yum-config-manager --enable rhel-7-server-optional-rpms && \
-    yum install -y --setopt=tsflags=nodocs rh-thermostat16 && \
+    INSTALL_PKGS="rh-thermostat16 && \
+    yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
     yum erase -y java-1.8.0-openjdk-headless && \
     yum clean all
+
 COPY thermostat-user-home-config ${USER_THERMOSTAT_HOME}
 COPY root /
 

--- a/16-storage/Dockerfile.rhel7
+++ b/16-storage/Dockerfile.rhel7
@@ -41,7 +41,7 @@ RUN yum install -y yum-utils && \
     yum clean all
     
 COPY thermostat-user-home-config ${THERMOSTAT_ROOT}
-ADD root /
+COPY root /
 
 # Get prefix path and path to scripts rather than hard-code them in scripts
 ENV CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/thermostat \

--- a/16-storage/Dockerfile.rhel7
+++ b/16-storage/Dockerfile.rhel7
@@ -36,7 +36,9 @@ EXPOSE 8080
 RUN yum install -y yum-utils && \
     yum-config-manager --enable rhel-server-rhscl-7-rpms && \
     yum-config-manager --enable rhel-7-server-optional-rpms && \
-    yum install -y --setopt=tsflags=nodocs rh-thermostat16 && \
+    INSTALL_PKGS="rh-thermostat16 && \
+    yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
     yum erase -y java-1.8.0-openjdk-headless && \
     yum clean all
     

--- a/16-storage/Dockerfile.rhel7
+++ b/16-storage/Dockerfile.rhel7
@@ -38,7 +38,7 @@ EXPOSE 8080
 RUN yum install -y yum-utils && \
     yum-config-manager --enable rhel-server-rhscl-7-rpms && \
     yum-config-manager --enable rhel-7-server-optional-rpms && \
-    INSTALL_PKGS="rh-thermostat16 && \
+    INSTALL_PKGS="rh-thermostat16" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \
     yum erase -y java-1.8.0-openjdk-headless && \

--- a/16-storage/Dockerfile.rhel7
+++ b/16-storage/Dockerfile.rhel7
@@ -18,15 +18,17 @@ FROM rhel7
 ENV THERMOSTAT_VERSION=1.6 \
     HOME=/home/tomcat
 
-LABEL io.k8s.description="A monitoring and serviceability tool for OpenJDK." \
-      io.k8s.display-name="Thermostat Storage 1.6"
+ENV SUMMARY="A monitoring and serviceability tool for OpenJDK."	\
+    DESCRIPTION="The powerful, free and open source instrumentation tool for the Hotspot JVM."
 
-# Labels consumed by Red Hat build service
-LABEL com.redhat.component="rh-thermostat16-storage-docker" \
+LABEL summary="$SUMMARY" \
+      description="$DESCRIPTION" \
+      io.k8s.description="$SUMMARY" \
+      io.k8s.display-name="Thermostat Storage 1.6" \
+      com.redhat.component="rh-thermostat16-storage-docker" \
       name="rhscl/thermostat-16-storage-rhel7" \
       version="1.6" \
-      release="1" \
-      architecture="x86_64"
+      release="1"
 
 ENV THERMOSTAT_HOME=/opt/rh/rh-thermostat16/root/usr/share/thermostat
 ENV THERMOSTAT_ROOT=/opt/rh/rh-thermostat16/root


### PR DESCRIPTION
Use COPY instruction instead of ADD
(COPY is preffered for simple usage - see https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#add-or-copy)

Provide same labels for all base image variants (CentOS, RHEL)
 - follow recomended labels from Project Atomic Container best practices
 - add summary and description labels - use ENV for simple using of same value in more descriptive labels
 - remove architecture label for RHEL based images (this label is set in RHEL image - no need to define it again)
                                           
(don't use separate instruction for each label)

Verify installed packages by `rpm -V`.

@hhorak @praiskup @pkubatrh Please take a look and merge.