### PR TITLE
Test and build also 16-agent and 16-storage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Variables are documented in common/build.sh.
 BASE_IMAGE_NAME = thermostat
-VERSIONS = 1-agent
+VERSIONS = 1-agent 16-agent  16-storage
 OPENSHIFT_NAMESPACES = 
 
 # HACK:  Ensure that 'git pull' for old clones doesn't cause confusion.


### PR DESCRIPTION
16-agent and 16-storage are missing in `Makefile`.

So after this change all versions will be built/test by default.

Needed by #14 and #15 