### PR TITLE
Add 16-agent and 16-storage Dockerfiles

### DIFF
--- a/16-agent/Dockerfile
+++ b/16-agent/Dockerfile
@@ -1,0 +1,68 @@
+FROM centos:centos7
+# Thermostat Agent Image.
+#
+# Volumes:
+#  * /opt/rh/rh-thermostat16/root/usr/share/thermostat
+# Environment:
+#  * $THERMOSTAT_CMDC_PORT      - The command channel listen port.
+#  * $THERMOSTAT_CMDC_ADDR      - The command channel listen address.
+#  * $THERMOSTAT_AGENT_USERNAME - User name for the thermostat agent to use
+#                                 for connecting to storage.
+#  * $THERMOSTAT_AGENT_PASSWORD - Password for the thermostat agent to use
+#                                 for connecting to storage.
+#  * $THERMOSTAT_DB_URL         - The storage URL to connect to.
+
+ENV THERMOSTAT_VERSION=1.6 \
+    HOME=/root
+
+ENV SUMMARY="A monitoring and serviceability tool for OpenJDK."	\
+    DESCRIPTION="The powerful, free and open source instrumentation tool for the Hotspot JVM."
+
+LABEL summary="$SUMMARY" \
+      description="$DESCRIPTION" \
+      io.k8s.description="$SUMMARY" \
+      io.k8s.display-name="Thermostat Agent 1.6" \
+      com.redhat.component="rh-thermostat16-agent-docker" \
+      name="centos/thermostat-16-agent-centos7" \
+      version="1.6" \
+      release="1"
+
+ENV THERMOSTAT_CMDC_ADDR 127.0.0.1
+ENV THERMOSTAT_CMDC_PORT 12000
+ENV THERMOSTAT_DB_URL http://127.0.0.1:8999/thermostat/storage
+ENV THERMOSTAT_HOME /opt/rh/rh-thermostat16/root/usr/share/thermostat
+ENV THERMOSTAT_JARS /opt/rh/rh-thermostat16/root/usr/share/java/thermostat
+ENV USER_THERMOSTAT_HOME /root/.thermostat-1.6
+
+EXPOSE $THERMOSTAT_CMDC_PORT
+
+RUN yum install -y yum-utils && \
+    INSTALL_PKGS="rh-thermostat16" && \
+    yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
+    yum erase -y java-1.8.0-openjdk-headless && \
+    yum clean all
+
+COPY thermostat-user-home-config ${USER_THERMOSTAT_HOME}
+COPY root /
+
+# Get prefix path and path to scripts rather than hard-code them in scripts
+ENV CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/thermostat \
+    ENABLED_COLLECTIONS=rh-thermostat16
+
+# When bash is started non-interactively, to run a shell script, for example it
+# looks for this variable and source the content of this file. This will enable
+# the SCL for all scripts without need to do 'scl enable'.
+ENV BASH_ENV=${CONTAINER_SCRIPTS_PATH}/scl_enable \
+    ENV=${CONTAINER_SCRIPTS_PATH}/scl_enable \
+    PROMPT_COMMAND=". ${CONTAINER_SCRIPTS_PATH}/scl_enable"
+
+# For the agent vm-profiler to work thermostat jars need to be available to other containers
+# using the volumes from this container.
+VOLUME ${THERMOSTAT_JARS}
+VOLUME ${THERMOSTAT_HOME}
+
+WORKDIR ${THERMOSTAT_HOME}
+
+ENTRYPOINT ["container-entrypoint"]
+CMD [ "run-thermostat-agent" ]

--- a/16-agent/Dockerfile
+++ b/16-agent/Dockerfile
@@ -36,7 +36,8 @@ ENV USER_THERMOSTAT_HOME /root/.thermostat-1.6
 
 EXPOSE $THERMOSTAT_CMDC_PORT
 
-RUN yum install -y yum-utils && \
+RUN yum install -y yum-utils centos-release-scl-rh && \
+    yum-config-manager --enable centos-sclo-rh-testing && \
     INSTALL_PKGS="rh-thermostat16" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \

--- a/16-storage/Dockerfile
+++ b/16-storage/Dockerfile
@@ -1,0 +1,70 @@
+FROM centos:centos7
+# Thermostat Storage Image.
+#
+# Environment:
+#  * $THERMOSTAT_AGENT_USERNAME  - User name for thermostat agents to use
+#                                  for connecting to storage.
+#  * $THERMOSTAT_AGENT_PASSWORD  - Password for thermostat agents to use
+#                                  for connecting to storage.
+#  * $THERMOSTAT_CLIENT_USERNAME - User name for thermostat clients to
+#                                  use for connecting to storage
+#  * $THERMOSTAT_CLIENT_PASSWORD - PASSWORD for thermostat clients to
+#                                  use for connecting to storage
+#  * $THERMOSTAT_DB_PORT         - The port to listen on
+#  * $MONGO_USERNAME             - User name to connect to the mongodb backend
+#  * $MONGO_PASSWORD             - Password to connect to the mongodb backend
+#  * $MONGO_URL                  - The mongodb url to connect to
+
+ENV THERMOSTAT_VERSION=1.6 \
+    HOME=/home/tomcat
+
+ENV SUMMARY="A monitoring and serviceability tool for OpenJDK."	\
+    DESCRIPTION="The powerful, free and open source instrumentation tool for the Hotspot JVM."
+
+LABEL summary="$SUMMARY" \
+      description="$DESCRIPTION" \
+      io.k8s.description="$SUMMARY" \
+      io.k8s.display-name="Thermostat Storage 1.6" \
+      com.redhat.component="rh-thermostat16-storage-docker" \
+      name="centos/thermostat-16-storage-centos7" \
+      version="1.6" \
+      release="1"
+
+ENV THERMOSTAT_HOME=/opt/rh/rh-thermostat16/root/usr/share/thermostat
+ENV THERMOSTAT_ROOT=/opt/rh/rh-thermostat16/root
+
+EXPOSE 8080
+
+RUN yum install -y yum-utils && \
+    INSTALL_PKGS="rh-thermostat16" && \
+    yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
+    rpm -V $INSTALL_PKGS && \
+    yum erase -y java-1.8.0-openjdk-headless && \
+    yum clean all
+    
+COPY thermostat-user-home-config ${THERMOSTAT_ROOT}
+COPY root /
+
+# Get prefix path and path to scripts rather than hard-code them in scripts
+ENV CONTAINER_SCRIPTS_PATH=/usr/share/container-scripts/thermostat \
+    ENABLED_COLLECTIONS=rh-thermostat16
+
+# When bash is started non-interactively, to run a shell script, for example it
+# looks for this variable and source the content of this file. This will enable
+# the SCL for all scripts without need to do 'scl enable'.
+ENV BASH_ENV=${CONTAINER_SCRIPTS_PATH}/scl_enable \
+    ENV=${CONTAINER_SCRIPTS_PATH}/scl_enable \
+    PROMPT_COMMAND=". ${CONTAINER_SCRIPTS_PATH}/scl_enable"
+
+RUN mkdir -p /home/tomcat && chown -R tomcat:tomcat /home/tomcat
+
+RUN [ "thermostat-storage-bootstrap" ]
+
+# the tomcat uid is generally 91
+USER 91
+
+WORKDIR /home/tomcat
+
+ENTRYPOINT ["container-entrypoint"]
+
+CMD [ "run-thermostat-storage" ]

--- a/16-storage/Dockerfile
+++ b/16-storage/Dockerfile
@@ -35,7 +35,8 @@ ENV THERMOSTAT_ROOT=/opt/rh/rh-thermostat16/root
 
 EXPOSE 8080
 
-RUN yum install -y yum-utils && \
+RUN yum install -y yum-utils centos-release-scl-rh && \
+    yum-config-manager --enable centos-sclo-rh-testing && \
     INSTALL_PKGS="rh-thermostat16" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     rpm -V $INSTALL_PKGS && \

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Variables are documented in common/build.sh.
 BASE_IMAGE_NAME = thermostat
-VERSIONS = 1-agent
+VERSIONS = 1-agent 16-agent  16-storage
 OPENSHIFT_NAMESPACES = 
 
 # HACK:  Ensure that 'git pull' for old clones doesn't cause confusion.

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Variables are documented in common/build.sh.
 BASE_IMAGE_NAME = thermostat
-VERSIONS = 1-agent 16-agent  16-storage
+VERSIONS = 1-agent
 OPENSHIFT_NAMESPACES = 
 
 # HACK:  Ensure that 'git pull' for old clones doesn't cause confusion.


### PR DESCRIPTION
Add CentOS Dockerfiles for 16-agent and 16-storage.

There are two reasons why not to build it by default (update `VERSIONS =` in `Makefile`):

- some required packages in CentOS are not tagged in `centos-sclo-rh-testing` repository yet (I will take a look in it)
- #14 and #15 fixes are required to build image correctly